### PR TITLE
Nissix plugin scope-packages on @wix/test

### DIFF
--- a/.module.json
+++ b/.module.json
@@ -14,6 +14,8 @@
     "teamName": "test"
   },
   "experiments": {
-    "scopes": ["test"]
+    "scopes": [
+      "test"
+    ]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3672,6 +3672,15 @@
       "integrity": "sha1-M2utwb7sudrMOL6izzKt9ieoQho=",
       "dev": true
     },
+    "@types/archiver": {
+      "version": "5.1.0",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@types/archiver/-/archiver-5.1.0.tgz",
+      "integrity": "sha1-hp9M5AKOSc+aAkPPkUQV9Mw9Hz0=",
+      "dev": true,
+      "requires": {
+        "@types/glob": "*"
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.12",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@types/babel__core/-/babel__core-7.1.12.tgz",
@@ -3761,6 +3770,15 @@
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@types/node/-/node-14.14.13.tgz",
           "integrity": "sha1-nkJQeXmTIhE66Edyl65u9RuODN8="
         }
+      }
+    },
+    "@types/chalk": {
+      "version": "2.2.0",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@types/chalk/-/chalk-2.2.0.tgz",
+      "integrity": "sha1-t/bkRvRRECnujj9DB1+1tz+6oLo=",
+      "dev": true,
+      "requires": {
+        "chalk": "*"
       }
     },
     "@types/chance": {
@@ -3998,12 +4016,6 @@
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@types/mime/-/mime-2.0.3.tgz",
       "integrity": "sha1-yJO3NyHbc2mZQ7/DZTsd63+qSjo="
     },
-    "@types/mime-types": {
-      "version": "2.1.0",
-      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@types/mime-types/-/mime-types-2.1.0.tgz",
-      "integrity": "sha1-nKUs2jY/aZxpRmwqbM2q2RPqenM=",
-      "dev": true
-    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -4196,6 +4208,25 @@
       "integrity": "sha1-qcpLcKGLJwzLK8Cqr+/R1Ia36nQ=",
       "dev": true
     },
+    "@types/tar-fs": {
+      "version": "2.0.0",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@types/tar-fs/-/tar-fs-2.0.0.tgz",
+      "integrity": "sha1-25TLTqHMzsr+PRpTgSgH77S728E=",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/tar-stream": "*"
+      }
+    },
+    "@types/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@types/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha1-J3jvjjKKUglZo5aBwVyDxTVTQm8=",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/testing-library__dom": {
       "version": "6.14.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@types/testing-library__dom/-/testing-library__dom-6.14.0.tgz",
@@ -4375,6 +4406,16 @@
       "version": "15.0.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
       "integrity": "sha1-yz+fdBhp4gzOMw/765JxWQSDiC0="
+    },
+    "@types/yauzl": {
+      "version": "2.9.1",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@types/yauzl/-/yauzl-2.9.1.tgz",
+      "integrity": "sha1-0Q9p+fUi7vPPmOMK+2hKHh7JI68=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "2.34.0",
@@ -9183,6 +9224,1519 @@
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
+        }
+      }
+    },
+    "@wix/sled-build-details": {
+      "version": "1.0.13",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@wix/sled-build-details/-/@wix/sled-build-details-1.0.13.tgz",
+      "integrity": "sha1-LjJVl3C0agpKt5+gv8RUA7EeDd8=",
+      "dev": true,
+      "requires": {
+        "@wix/ci-build-info": "1.0.176",
+        "node-fetch": "^2.6.0"
+      },
+      "dependencies": {
+        "@wix/artifact-description": {
+          "version": "1.0.241",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@wix/artifact-description/-/@wix/artifact-description-1.0.241.tgz",
+          "integrity": "sha1-W4wkUGXq3ZL0Xk54KekP2MU0d+Y=",
+          "dev": true,
+          "requires": {
+            "@wix/fed-build-flow-runner-error": "1.0.268",
+            "fast-xml-parser": "^3.17.4"
+          }
+        },
+        "@wix/ci-build-info": {
+          "version": "1.0.176",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@wix/ci-build-info/-/@wix/ci-build-info-1.0.176.tgz",
+          "integrity": "sha1-lsWSBMjatGux34ZhSOkYLHyv1WA=",
+          "dev": true,
+          "requires": {
+            "@lerna/project": "^3.21.0",
+            "@wix/artifact-description": "1.0.241",
+            "tmp": "^0.2.1",
+            "zod": "1.7.1"
+          }
+        },
+        "@wix/fed-build-flow-runner-error": {
+          "version": "1.0.268",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@wix/fed-build-flow-runner-error/-/@wix/fed-build-flow-runner-error-1.0.268.tgz",
+          "integrity": "sha1-k7XMFgTh9u8YeoTbY6TecBLc6ew=",
+          "dev": true,
+          "requires": {
+            "verror": "^1.10.0"
+          }
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "tmp": {
+          "version": "0.2.1",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/tmp/-/tmp-0.2.1.tgz",
+          "integrity": "sha1-hFf8MDfc9HGcJRNnoa9lAO4czxQ=",
+          "dev": true,
+          "requires": {
+            "rimraf": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@wix/sled-test-runner": {
+      "version": "1.0.937",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@wix/sled-test-runner/-/@wix/sled-test-runner-1.0.937.tgz",
+      "integrity": "sha1-NikQl9CzVpvXGi60dD8qzpRkF44=",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-proposal-class-properties": "^7.1.0",
+        "@babel/plugin-proposal-decorators": "^7.8.3",
+        "@babel/plugin-syntax-dynamic-import": "^7.0.0",
+        "@babel/plugin-transform-runtime": "^7.1.0",
+        "@babel/preset-env": "^7.1.0",
+        "@babel/preset-react": "^7.0.0",
+        "@babel/runtime": "7.7.6",
+        "@types/archiver": "^5.1.0",
+        "@types/chalk": "^2.2.0",
+        "@types/jest": "^24.0.11",
+        "@types/jest-image-snapshot": "^2.8.0",
+        "@types/node": "^12.19.7",
+        "@types/puppeteer": "^1.12.2",
+        "@types/vfile-message": "^2.0.0",
+        "@wix/artifact-description": "1.0.241",
+        "@wix/ci-build-info": "1.0.176",
+        "@wix/puppeteer-interception-pipeline": "^1.0.155",
+        "@wix/sheshesh-image-snapshot": "^1.0.283",
+        "@wix/sled-build-details": "1.0.13",
+        "@wix/suricate-client": "^0.0.3",
+        "@zeit/webpack-asset-relocator-loader": "^0.8.0",
+        "archiver": "^5.2.0",
+        "async-retry": "^1.3.1",
+        "aws-sdk": "^2.701.0",
+        "babel-jest": "^24.4.0",
+        "babel-loader": "^8.0.6",
+        "babel-plugin-dynamic-import-node": "^2.2.0",
+        "body-parser": "^1.19.0",
+        "chalk": "^4.1.0",
+        "chokidar": "*",
+        "chrome-har": "^0.11.12",
+        "chrome-launcher": "^0.13.4",
+        "cloud-manager": "1.0.44",
+        "command-line-args": "^5.0.2",
+        "command-line-usage": "^5.0.5",
+        "dependency-tree": "^7.0.2",
+        "express": "^4.17.1",
+        "fs-extra": "^8.0.1",
+        "globby": "^11.0.1",
+        "google-authenticator": "1.0.80",
+        "ini": "^1.3.5",
+        "is-ci": "^2.0.0",
+        "jest": "24.1.0",
+        "jest-runner-aws-lambda": "1.0.331",
+        "jest-teamcity": "^1.9.0",
+        "lodash": "^4.17.11",
+        "match-screenshot": "^3.0.131",
+        "micromatch": "^3.1.10",
+        "mime-types": "^2.1.27",
+        "node-fetch": "^2.6.0",
+        "node-notifier": "^6.0.0",
+        "null-loader": "^3.0.0",
+        "open": "^7.0.0",
+        "p-queue": "^6.6.2",
+        "puppeteer-core": "^5.5.0",
+        "shelljs": "^0.8.3",
+        "sled-config": "2.0.273",
+        "snowmobile-runner": "1.0.158",
+        "stream": "0.0.2",
+        "tar": "^4.4.8",
+        "terser-webpack-plugin": "^4.1.0",
+        "thread-loader": "^2.1.3",
+        "ts-jest": "^24.0.0",
+        "ts-loader": "^8.0.14",
+        "uuid": "^8.3.2",
+        "webpack": "5.11.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.7.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "@types/json-schema": {
+          "version": "7.0.6",
+          "bundled": true,
+          "dev": true
+        },
+        "@types/node": {
+          "version": "12.20.4",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@types/node/-/node-12.20.4.tgz",
+          "integrity": "sha1-c2hwQ90A/LaWLGD79JlVOiTWvfI=",
+          "dev": true
+        },
+        "@webassemblyjs/ast": {
+          "version": "1.9.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/helper-module-context": "1.9.1",
+            "@webassemblyjs/helper-wasm-bytecode": "1.9.1",
+            "@webassemblyjs/wast-parser": "1.9.1"
+          }
+        },
+        "@webassemblyjs/floating-point-hex-parser": {
+          "version": "1.9.1",
+          "bundled": true,
+          "dev": true
+        },
+        "@webassemblyjs/helper-api-error": {
+          "version": "1.9.1",
+          "bundled": true,
+          "dev": true
+        },
+        "@webassemblyjs/helper-buffer": {
+          "version": "1.9.1",
+          "bundled": true,
+          "dev": true
+        },
+        "@webassemblyjs/helper-code-frame": {
+          "version": "1.9.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/wast-printer": "1.9.1"
+          }
+        },
+        "@webassemblyjs/helper-fsm": {
+          "version": "1.9.1",
+          "bundled": true,
+          "dev": true
+        },
+        "@webassemblyjs/helper-module-context": {
+          "version": "1.9.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.1"
+          }
+        },
+        "@webassemblyjs/helper-wasm-bytecode": {
+          "version": "1.9.1",
+          "bundled": true,
+          "dev": true
+        },
+        "@webassemblyjs/helper-wasm-section": {
+          "version": "1.9.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.1",
+            "@webassemblyjs/helper-buffer": "1.9.1",
+            "@webassemblyjs/helper-wasm-bytecode": "1.9.1",
+            "@webassemblyjs/wasm-gen": "1.9.1"
+          }
+        },
+        "@webassemblyjs/ieee754": {
+          "version": "1.9.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@xtuc/ieee754": "^1.2.0"
+          }
+        },
+        "@webassemblyjs/leb128": {
+          "version": "1.9.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@xtuc/long": "4.2.2"
+          }
+        },
+        "@webassemblyjs/utf8": {
+          "version": "1.9.1",
+          "bundled": true,
+          "dev": true
+        },
+        "@webassemblyjs/wasm-edit": {
+          "version": "1.9.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.1",
+            "@webassemblyjs/helper-buffer": "1.9.1",
+            "@webassemblyjs/helper-wasm-bytecode": "1.9.1",
+            "@webassemblyjs/helper-wasm-section": "1.9.1",
+            "@webassemblyjs/wasm-gen": "1.9.1",
+            "@webassemblyjs/wasm-opt": "1.9.1",
+            "@webassemblyjs/wasm-parser": "1.9.1",
+            "@webassemblyjs/wast-printer": "1.9.1"
+          }
+        },
+        "@webassemblyjs/wasm-gen": {
+          "version": "1.9.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.1",
+            "@webassemblyjs/helper-wasm-bytecode": "1.9.1",
+            "@webassemblyjs/ieee754": "1.9.1",
+            "@webassemblyjs/leb128": "1.9.1",
+            "@webassemblyjs/utf8": "1.9.1"
+          }
+        },
+        "@webassemblyjs/wasm-opt": {
+          "version": "1.9.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.1",
+            "@webassemblyjs/helper-buffer": "1.9.1",
+            "@webassemblyjs/wasm-gen": "1.9.1",
+            "@webassemblyjs/wasm-parser": "1.9.1"
+          }
+        },
+        "@webassemblyjs/wasm-parser": {
+          "version": "1.9.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.1",
+            "@webassemblyjs/helper-api-error": "1.9.1",
+            "@webassemblyjs/helper-wasm-bytecode": "1.9.1",
+            "@webassemblyjs/ieee754": "1.9.1",
+            "@webassemblyjs/leb128": "1.9.1",
+            "@webassemblyjs/utf8": "1.9.1"
+          }
+        },
+        "@webassemblyjs/wast-parser": {
+          "version": "1.9.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.1",
+            "@webassemblyjs/floating-point-hex-parser": "1.9.1",
+            "@webassemblyjs/helper-api-error": "1.9.1",
+            "@webassemblyjs/helper-code-frame": "1.9.1",
+            "@webassemblyjs/helper-fsm": "1.9.1",
+            "@xtuc/long": "4.2.2"
+          }
+        },
+        "@webassemblyjs/wast-printer": {
+          "version": "1.9.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.1",
+            "@webassemblyjs/wast-parser": "1.9.1",
+            "@xtuc/long": "4.2.2"
+          }
+        },
+        "@wix/artifact-description": {
+          "version": "1.0.241",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@wix/artifact-description/-/@wix/artifact-description-1.0.241.tgz",
+          "integrity": "sha1-W4wkUGXq3ZL0Xk54KekP2MU0d+Y=",
+          "dev": true,
+          "requires": {
+            "@wix/fed-build-flow-runner-error": "1.0.268",
+            "fast-xml-parser": "^3.17.4"
+          }
+        },
+        "@wix/ci-build-info": {
+          "version": "1.0.176",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@wix/ci-build-info/-/@wix/ci-build-info-1.0.176.tgz",
+          "integrity": "sha1-lsWSBMjatGux34ZhSOkYLHyv1WA=",
+          "dev": true,
+          "requires": {
+            "@lerna/project": "^3.21.0",
+            "@wix/artifact-description": "1.0.241",
+            "tmp": "^0.2.1",
+            "zod": "1.7.1"
+          }
+        },
+        "@wix/fed-build-flow-runner-error": {
+          "version": "1.0.268",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@wix/fed-build-flow-runner-error/-/@wix/fed-build-flow-runner-error-1.0.268.tgz",
+          "integrity": "sha1-k7XMFgTh9u8YeoTbY6TecBLc6ew=",
+          "dev": true,
+          "requires": {
+            "verror": "^1.10.0"
+          }
+        },
+        "acorn": {
+          "version": "8.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "agent-base": {
+          "version": "5.1.1",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/agent-base/-/agent-base-5.1.1.tgz",
+          "integrity": "sha1-6Ps/JClZ20TWO+Zl23qOc5U3oyw=",
+          "dev": true
+        },
+        "aggregate-error": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "clean-stack": "^2.0.0",
+            "indent-string": "^4.0.0"
+          }
+        },
+        "ajv": {
+          "version": "6.12.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "archiver": {
+          "version": "5.2.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/archiver/-/archiver-5.2.0.tgz",
+          "integrity": "sha1-JaobPZ/r967FsPKW535plgwm25Q=",
+          "dev": true,
+          "requires": {
+            "archiver-utils": "^2.1.0",
+            "async": "^3.2.0",
+            "buffer-crc32": "^0.2.1",
+            "readable-stream": "^3.6.0",
+            "readdir-glob": "^1.0.0",
+            "tar-stream": "^2.1.4",
+            "zip-stream": "^4.0.4"
+          }
+        },
+        "babel-loader": {
+          "version": "8.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "find-cache-dir": "^2.0.0",
+            "loader-utils": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "pify": "^4.0.1"
+          }
+        },
+        "bl": {
+          "version": "4.1.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/bl/-/bl-4.1.0.tgz",
+          "integrity": "sha1-RRU1JkGCvsL7vIOmKrmM8R2fezo=",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "inherits": "^2.0.4",
+            "readable-stream": "^3.4.0"
+          }
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "browserslist": {
+          "version": "4.14.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30001157",
+            "colorette": "^1.2.1",
+            "electron-to-chromium": "^1.3.591",
+            "escalade": "^3.1.1",
+            "node-releases": "^1.1.66"
+          }
+        },
+        "cacache": {
+          "version": "15.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/move-file": "^1.0.1",
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.0.0",
+            "glob": "^7.1.4",
+            "infer-owner": "^1.0.4",
+            "lru-cache": "^6.0.0",
+            "minipass": "^3.1.1",
+            "minipass-collect": "^1.0.2",
+            "minipass-flush": "^1.0.5",
+            "minipass-pipeline": "^1.2.2",
+            "mkdirp": "^1.0.3",
+            "p-map": "^4.0.0",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^3.0.2",
+            "ssri": "^8.0.0",
+            "tar": "^6.0.2",
+            "unique-filename": "^1.1.1"
+          },
+          "dependencies": {
+            "mkdirp": {
+              "version": "1.0.4",
+              "bundled": true,
+              "dev": true
+            },
+            "tar": {
+              "version": "6.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "chownr": "^2.0.0",
+                "fs-minipass": "^2.0.0",
+                "minipass": "^3.0.0",
+                "minizlib": "^2.1.0",
+                "mkdirp": "^1.0.3",
+                "yallist": "^4.0.0"
+              }
+            }
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001164",
+          "bundled": true,
+          "dev": true
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "chownr": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "chrome-launcher": {
+          "version": "0.13.4",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/chrome-launcher/-/chrome-launcher-0.13.4.tgz",
+          "integrity": "sha1-TH2BMzyYKCiZxOOCVtoj4A7TL3M=",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "escape-string-regexp": "^1.0.5",
+            "is-wsl": "^2.2.0",
+            "lighthouse-logger": "^1.0.0",
+            "mkdirp": "^0.5.3",
+            "rimraf": "^3.0.2"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
+        "compress-commons": {
+          "version": "4.1.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/compress-commons/-/compress-commons-4.1.0.tgz",
+          "integrity": "sha1-Jex6RSiFLM0dRBp9Q1PNDs4RNxs=",
+          "dev": true,
+          "requires": {
+            "buffer-crc32": "^0.2.13",
+            "crc32-stream": "^4.0.1",
+            "normalize-path": "^3.0.0",
+            "readable-stream": "^3.6.0"
+          }
+        },
+        "crc32-stream": {
+          "version": "4.0.2",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/crc32-stream/-/crc32-stream-4.0.2.tgz",
+          "integrity": "sha1-ySKtIrODlavp04cPAvqBNO1wkAc=",
+          "dev": true,
+          "requires": {
+            "crc-32": "^1.2.0",
+            "readable-stream": "^3.4.0"
+          }
+        },
+        "devtools-protocol": {
+          "version": "0.0.818844",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/devtools-protocol/-/devtools-protocol-0.0.818844.tgz",
+          "integrity": "sha1-0ZRyeOyFtT5MjKWY9geij6eFup4=",
+          "dev": true
+        },
+        "electron-to-chromium": {
+          "version": "1.3.612",
+          "bundled": true,
+          "dev": true
+        },
+        "emojis-list": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "eslint-scope": {
+          "version": "5.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.3.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "esrecurse": {
+          "version": "4.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "estraverse": "^5.2.0"
+          },
+          "dependencies": {
+            "estraverse": {
+              "version": "5.2.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "extract-zip": {
+          "version": "2.0.1",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/extract-zip/-/extract-zip-2.0.1.tgz",
+          "integrity": "sha1-Zj3KVv5G34kNXxMe9KBtIruLoTo=",
+          "dev": true,
+          "requires": {
+            "@types/yauzl": "^2.9.1",
+            "debug": "^4.1.1",
+            "get-stream": "^5.1.0",
+            "yauzl": "^2.10.0"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
+          "dev": true
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "find-up": {
+          "version": "5.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha1-SdQ8RaiM2Wd2aMt74bRu/bjS4cA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "fs-minipass": {
+          "version": "2.1.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/fs-minipass/-/fs-minipass-2.1.0.tgz",
+          "integrity": "sha1-f1A2/b8SxjwWkZDL5BmchSJx+fs=",
+          "dev": true,
+          "requires": {
+            "minipass": "^3.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha1-SWaheV7lrOZecGxLe+txJX1uItM=",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "glob-to-regexp": {
+          "version": "0.4.1",
+          "bundled": true,
+          "dev": true
+        },
+        "google-authenticator": {
+          "version": "1.0.80",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/google-authenticator/-/google-authenticator-1.0.80.tgz",
+          "integrity": "sha1-73hq3UQiBpDvTbevVMyH/eMGaMA=",
+          "dev": true,
+          "requires": {
+            "express": "^4.17.1",
+            "open": "^7.3.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "https-proxy-agent": {
+          "version": "4.0.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
+          "integrity": "sha1-cCtx+1UgoTKmbeH2dUHZ5iFU2Cs=",
+          "dev": true,
+          "requires": {
+            "agent-base": "5",
+            "debug": "4"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "is-wsl": {
+          "version": "2.2.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-wsl/-/is-wsl-2.2.0.tgz",
+          "integrity": "sha1-dKTHbnfKn9P5MvKQwX6jJs0VcnE=",
+          "dev": true,
+          "requires": {
+            "is-docker": "^2.0.0"
+          }
+        },
+        "jest-runner-aws-lambda": {
+          "version": "1.0.331",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/jest-runner-aws-lambda/-/jest-runner-aws-lambda-1.0.331.tgz",
+          "integrity": "sha1-uGKx4ftNpmVKn1CtMTIH+i7KeEU=",
+          "dev": true,
+          "requires": {
+            "@wix/build-output-client": "1.0.156",
+            "aws-sdk": "^2.701.0",
+            "command-line-args": "^5.0.2",
+            "fed-tests-bi": "1.0.4",
+            "hot-shots": "^6.8.1",
+            "jest-teamcity": "^1.9.0",
+            "lodash": "^4.17.10",
+            "node-fetch": "^2.6.0",
+            "p-limit": "^3.0.1",
+            "request": "^2.88.0",
+            "shell-escape": "^0.2.0"
+          }
+        },
+        "jest-worker": {
+          "version": "26.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "merge-stream": "^2.0.0",
+            "supports-color": "^7.0.0"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "13.7.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "json5": {
+          "version": "2.2.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/json5/-/json5-2.2.0.tgz",
+          "integrity": "sha1-Lf7+cgxrpSXZ69kJlQ8FFTFsiaM=",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "loader-runner": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "make-dir": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "semver": "^6.0.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "mime-db": {
+          "version": "1.44.0",
+          "bundled": true,
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.27",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mime-db": "1.44.0"
+          }
+        },
+        "minipass": {
+          "version": "3.1.3",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/minipass/-/minipass-3.1.3.tgz",
+          "integrity": "sha1-fUL/HzljVILhX5zbUxhN7r1YFf0=",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minipass": "^3.0.0",
+            "yallist": "^4.0.0"
+          }
+        },
+        "neo-async": {
+          "version": "2.6.2",
+          "bundled": true,
+          "dev": true
+        },
+        "node-releases": {
+          "version": "1.1.67",
+          "bundled": true,
+          "dev": true
+        },
+        "null-loader": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loader-utils": "^1.2.3",
+            "schema-utils": "^1.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "p-map": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aggregate-error": "^3.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "picomatch": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "5.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "find-up": "^5.0.0"
+          }
+        },
+        "puppeteer-core": {
+          "version": "5.5.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/puppeteer-core/-/puppeteer-core-5.5.0.tgz",
+          "integrity": "sha1-37Ymbv5akzy/GjaNJwJab9T1qIQ=",
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.0",
+            "devtools-protocol": "0.0.818844",
+            "extract-zip": "^2.0.0",
+            "https-proxy-agent": "^4.0.0",
+            "node-fetch": "^2.6.1",
+            "pkg-dir": "^4.2.0",
+            "progress": "^2.0.1",
+            "proxy-from-env": "^1.0.0",
+            "rimraf": "^3.0.2",
+            "tar-fs": "^2.0.0",
+            "unbzip2-stream": "^1.3.3",
+            "ws": "^7.2.3"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "4.1.0",
+              "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/find-up/-/find-up-4.1.0.tgz",
+              "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
+              "dev": true,
+              "requires": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "5.0.0",
+              "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/locate-path/-/locate-path-5.0.0.tgz",
+              "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
+              "dev": true,
+              "requires": {
+                "p-locate": "^4.1.0"
+              }
+            },
+            "p-limit": {
+              "version": "2.3.0",
+              "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/p-limit/-/p-limit-2.3.0.tgz",
+              "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
+              "dev": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "4.1.0",
+              "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/p-locate/-/p-locate-4.1.0.tgz",
+              "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
+              "dev": true,
+              "requires": {
+                "p-limit": "^2.2.0"
+              }
+            },
+            "pkg-dir": {
+              "version": "4.2.0",
+              "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/pkg-dir/-/pkg-dir-4.2.0.tgz",
+              "integrity": "sha1-8JkTPfft5CLoHR2ESCcO6z5CYfM=",
+              "dev": true,
+              "requires": {
+                "find-up": "^4.0.0"
+              }
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "bundled": true,
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/schema-utils/-/schema-utils-1.0.0.tgz",
+          "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "sled-config": {
+          "version": "2.0.273",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/sled-config/-/sled-config-2.0.273.tgz",
+          "integrity": "sha1-CK73EEBglQBLm2d5vCmjW/omGkE=",
+          "dev": true
+        },
+        "snowmobile-runner": {
+          "version": "1.0.158",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/snowmobile-runner/-/snowmobile-runner-1.0.158.tgz",
+          "integrity": "sha1-iAdNE0zx6U+qETdz/fk0Y69nkgM=",
+          "dev": true,
+          "requires": {
+            "@wix/build-output-client": "1.0.156",
+            "@wix/sled-build-details": "1.0.13",
+            "aws-sdk": "^2.701.0",
+            "lodash": "^4.17.15",
+            "p-limit": "^3.0.1"
+          }
+        },
+        "source-map-support": {
+          "version": "0.5.16",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        },
+        "ssri": {
+          "version": "8.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minipass": "^3.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "tapable": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "tar-stream": {
+          "version": "2.2.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/tar-stream/-/tar-stream-2.2.0.tgz",
+          "integrity": "sha1-rK2EwoQTawYNw/qmRHSqmuvXcoc=",
+          "dev": true,
+          "requires": {
+            "bl": "^4.0.3",
+            "end-of-stream": "^1.4.1",
+            "fs-constants": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.1.1"
+          }
+        },
+        "terser": {
+          "version": "5.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "commander": "^2.20.0",
+            "source-map": "~0.6.1",
+            "source-map-support": "~0.5.12"
+          }
+        },
+        "terser-webpack-plugin": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cacache": "^15.0.5",
+            "find-cache-dir": "^3.3.1",
+            "jest-worker": "^26.3.0",
+            "p-limit": "^3.0.2",
+            "schema-utils": "^2.6.6",
+            "serialize-javascript": "^4.0.0",
+            "source-map": "^0.6.1",
+            "terser": "^5.0.0",
+            "webpack-sources": "^1.4.3"
+          },
+          "dependencies": {
+            "find-cache-dir": {
+              "version": "3.3.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "commondir": "^1.0.1",
+                "make-dir": "^3.0.2",
+                "pkg-dir": "^4.1.0"
+              }
+            },
+            "find-up": {
+              "version": "4.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "5.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "p-locate": "^4.1.0"
+              }
+            },
+            "p-locate": {
+              "version": "4.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "p-limit": "^2.2.0"
+              },
+              "dependencies": {
+                "p-limit": {
+                  "version": "2.2.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "p-try": "^2.0.0"
+                  }
+                }
+              }
+            },
+            "pkg-dir": {
+              "version": "4.2.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "find-up": "^4.0.0"
+              }
+            },
+            "schema-utils": {
+              "version": "2.6.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ajv": "^6.12.0",
+                "ajv-keywords": "^3.4.1"
+              }
+            }
+          }
+        },
+        "tmp": {
+          "version": "0.2.1",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/tmp/-/tmp-0.2.1.tgz",
+          "integrity": "sha1-hFf8MDfc9HGcJRNnoa9lAO4czxQ=",
+          "dev": true,
+          "requires": {
+            "rimraf": "^3.0.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        },
+        "ts-loader": {
+          "version": "8.0.14",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "chalk": "^4.1.0",
+            "enhanced-resolve": "^4.0.0",
+            "loader-utils": "^2.0.0",
+            "micromatch": "^4.0.0",
+            "semver": "^7.3.4"
+          },
+          "dependencies": {
+            "braces": {
+              "version": "3.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "fill-range": "^7.0.1"
+              }
+            },
+            "fill-range": {
+              "version": "7.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "to-regex-range": "^5.0.1"
+              }
+            },
+            "is-number": {
+              "version": "7.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "loader-utils": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "big.js": "^5.2.2",
+                "emojis-list": "^3.0.0",
+                "json5": "^2.1.2"
+              }
+            },
+            "micromatch": {
+              "version": "4.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "braces": "^3.0.1",
+                "picomatch": "^2.0.5"
+              }
+            },
+            "to-regex-range": {
+              "version": "5.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-number": "^7.0.0"
+              }
+            }
+          }
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
+          "dev": true
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I=",
+          "dev": true
+        },
+        "watchpack": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob-to-regexp": "^0.4.1",
+            "graceful-fs": "^4.1.2"
+          }
+        },
+        "webpack": {
+          "version": "5.11.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@types/eslint-scope": "^3.7.0",
+            "@types/estree": "^0.0.45",
+            "@webassemblyjs/ast": "1.9.1",
+            "@webassemblyjs/helper-module-context": "1.9.1",
+            "@webassemblyjs/wasm-edit": "1.9.1",
+            "@webassemblyjs/wasm-parser": "1.9.1",
+            "acorn": "^8.0.4",
+            "browserslist": "^4.14.5",
+            "chrome-trace-event": "^1.0.2",
+            "enhanced-resolve": "^5.3.1",
+            "eslint-scope": "^5.1.1",
+            "events": "^3.2.0",
+            "glob-to-regexp": "^0.4.1",
+            "graceful-fs": "^4.2.4",
+            "json-parse-better-errors": "^1.0.2",
+            "loader-runner": "^4.1.0",
+            "mime-types": "^2.1.27",
+            "neo-async": "^2.6.2",
+            "pkg-dir": "^5.0.0",
+            "schema-utils": "^3.0.0",
+            "tapable": "^2.1.1",
+            "terser-webpack-plugin": "^5.0.3",
+            "watchpack": "^2.0.0",
+            "webpack-sources": "^2.1.1"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "13.7.2",
+              "bundled": true,
+              "dev": true
+            },
+            "ajv": {
+              "version": "6.12.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+              }
+            },
+            "ajv-keywords": {
+              "version": "3.5.2",
+              "bundled": true,
+              "dev": true
+            },
+            "enhanced-resolve": {
+              "version": "5.3.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.2.4",
+                "tapable": "^2.0.0"
+              },
+              "dependencies": {
+                "tapable": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "events": {
+              "version": "3.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "graceful-fs": {
+              "version": "4.2.4",
+              "bundled": true,
+              "dev": true
+            },
+            "jest-worker": {
+              "version": "26.6.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@types/node": "*",
+                "merge-stream": "^2.0.0",
+                "supports-color": "^7.0.0"
+              }
+            },
+            "schema-utils": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@types/json-schema": "^7.0.6",
+                "ajv": "^6.12.5",
+                "ajv-keywords": "^3.5.2"
+              }
+            },
+            "serialize-javascript": {
+              "version": "5.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "randombytes": "^2.1.0"
+              }
+            },
+            "source-map-support": {
+              "version": "0.5.19",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+              }
+            },
+            "terser": {
+              "version": "5.5.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "commander": "^2.20.0",
+                "source-map": "~0.7.2",
+                "source-map-support": "~0.5.19"
+              },
+              "dependencies": {
+                "source-map": {
+                  "version": "0.7.3",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "terser-webpack-plugin": {
+              "version": "5.0.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "jest-worker": "^26.6.1",
+                "p-limit": "^3.0.2",
+                "schema-utils": "^3.0.0",
+                "serialize-javascript": "^5.0.1",
+                "source-map": "^0.6.1",
+                "terser": "^5.3.8"
+              }
+            },
+            "webpack-sources": {
+              "version": "2.2.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "source-list-map": "^2.0.1",
+                "source-map": "^0.6.1"
+              }
+            }
+          }
+        },
+        "webpack-sources": {
+          "version": "1.4.3",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/webpack-sources/-/webpack-sources-1.4.3.tgz",
+          "integrity": "sha1-7t2OwLko+/HL/plOItLYkPMwqTM=",
+          "dev": true,
+          "requires": {
+            "source-list-map": "^2.0.0",
+            "source-map": "~0.6.1"
+          }
+        },
+        "ws": {
+          "version": "7.4.3",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/ws/-/ws-7.4.3.tgz",
+          "integrity": "sha1-H5ZD3jSlQ7jtsSS9y8RXrlWm5c0=",
+          "dev": true
+        },
+        "zip-stream": {
+          "version": "4.1.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/zip-stream/-/zip-stream-4.1.0.tgz",
+          "integrity": "sha1-Ud0yZXFUTjaqP3VkMLMTV23I/Hk=",
+          "dev": true,
+          "requires": {
+            "archiver-utils": "^2.1.0",
+            "compress-commons": "^4.1.0",
+            "readable-stream": "^3.6.0"
+          }
         }
       }
     },
@@ -14557,42 +16111,49 @@
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha1-b8nXtC0ypYNZYzdmbn0ICE2izGs="
     },
-    "chrome-launcher": {
-      "version": "0.11.2",
-      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/chrome-launcher/-/chrome-launcher-0.11.2.tgz",
-      "integrity": "sha1-yaJI28zToIVlVTrPYa3/h5vMmCw=",
+    "chrome-har": {
+      "version": "0.11.12",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/chrome-har/-/chrome-har-0.11.12.tgz",
+      "integrity": "sha1-KadaDZ67cMnEDY+9NcPbfU8BDiU=",
       "dev": true,
       "requires": {
-        "@types/node": "*",
-        "is-wsl": "^2.1.0",
-        "lighthouse-logger": "^1.0.0",
-        "mkdirp": "0.5.1",
-        "rimraf": "^2.6.1"
+        "dayjs": "1.8.31",
+        "debug": "4.1.1",
+        "tough-cookie": "4.0.0",
+        "uuid": "8.0.0"
       },
       "dependencies": {
-        "is-wsl": {
-          "version": "2.2.0",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-wsl/-/is-wsl-2.2.0.tgz",
-          "integrity": "sha1-dKTHbnfKn9P5MvKQwX6jJs0VcnE=",
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "dev": true,
           "requires": {
-            "is-docker": "^2.0.0"
+            "ms": "^2.1.1"
           }
         },
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+        "tough-cookie": {
+          "version": "4.0.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/tough-cookie/-/tough-cookie-4.0.0.tgz",
+          "integrity": "sha1-2CIjTuyogvmR8PkIgkrSYi3b7OQ=",
+          "dev": true,
+          "requires": {
+            "psl": "^1.1.33",
+            "punycode": "^2.1.1",
+            "universalify": "^0.1.2"
+          }
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
           "dev": true
         },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
+        "uuid": {
+          "version": "8.0.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/uuid/-/uuid-8.0.0.tgz",
+          "integrity": "sha1-vGzPkbX/CsB7vNvxx8ThUNtNu2w=",
+          "dev": true
         }
       }
     },
@@ -14742,6 +16303,85 @@
           "version": "1.0.1",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/mimic-response/-/mimic-response-1.0.1.tgz",
           "integrity": "sha1-SSNTiHju9CBjy4o+OweYeBSHqxs="
+        }
+      }
+    },
+    "cloud-manager": {
+      "version": "1.0.44",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/cloud-manager/-/cloud-manager-1.0.44.tgz",
+      "integrity": "sha1-2BVvY5YxL5h+/yAedxMcSPzIlS4=",
+      "dev": true,
+      "requires": {
+        "@types/tar-fs": "^2.0.0",
+        "aws-sdk": "^2.829.0",
+        "p-limit": "^3.1.0",
+        "tar-fs": "^2.0.0"
+      },
+      "dependencies": {
+        "aws-sdk": {
+          "version": "2.855.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/aws-sdk/-/aws-sdk-2.855.0.tgz",
+          "integrity": "sha1-J4jiZV2OLuz8nYasr9E9hycl5zo=",
+          "dev": true,
+          "requires": {
+            "buffer": "4.9.2",
+            "events": "1.1.1",
+            "ieee754": "1.1.13",
+            "jmespath": "0.15.0",
+            "querystring": "0.2.0",
+            "sax": "1.2.1",
+            "url": "0.10.3",
+            "uuid": "3.3.2",
+            "xml2js": "0.4.19"
+          }
+        },
+        "buffer": {
+          "version": "4.9.2",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/buffer/-/buffer-4.9.2.tgz",
+          "integrity": "sha1-Iw6tNEACmIZEhBqwJEr4xEu+Pvg=",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
+          }
+        },
+        "ieee754": {
+          "version": "1.1.13",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/ieee754/-/ieee754-1.1.13.tgz",
+          "integrity": "sha1-7BaFWOlaoYH9h9N/VcMrvLZwi4Q=",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha1-4drMvnjQ0TiMoYxk/qOOPlfjcGs=",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha1-G0r0lV6zB3xQHCOHL8ZROBFYcTE=",
+          "dev": true
+        },
+        "xml2js": {
+          "version": "0.4.19",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/xml2js/-/xml2js-0.4.19.tgz",
+          "integrity": "sha1-aGwg8hMgnpSr8NG88e+qKRx4J6c=",
+          "dev": true,
+          "requires": {
+            "sax": ">=0.6.0",
+            "xmlbuilder": "~9.0.1"
+          }
+        },
+        "xmlbuilder": {
+          "version": "9.0.7",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+          "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+          "dev": true
         }
       }
     },
@@ -16463,6 +18103,12 @@
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/dateformat/-/dateformat-3.0.3.tgz",
       "integrity": "sha1-puN0maTZqc+F71hyBE1ikByYia4="
     },
+    "dayjs": {
+      "version": "1.8.31",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/dayjs/-/dayjs-1.8.31.tgz",
+      "integrity": "sha1-DNERTCU53VrZQovgw4321LtAudM=",
+      "dev": true
+    },
     "debug": {
       "version": "4.3.1",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/debug/-/debug-4.3.1.tgz",
@@ -17392,6 +19038,12 @@
           "dev": true
         }
       }
+    },
+    "emitter-component": {
+      "version": "1.1.1",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/emitter-component/-/emitter-component-1.1.1.tgz",
+      "integrity": "sha1-Bl4tvtaVm/RwZ57avq95gdEAOrY=",
+      "dev": true
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -20099,16 +21751,6 @@
             "safe-buffer": "^5.0.1"
           }
         }
-      }
-    },
-    "google-authenticator": {
-      "version": "1.0.11",
-      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/google-authenticator/-/google-authenticator-1.0.11.tgz",
-      "integrity": "sha1-bAcZr/F2B+c4Q/5N9UGozx9HutA=",
-      "dev": true,
-      "requires": {
-        "express": "^4.17.1",
-        "open": "^7.3.0"
       }
     },
     "google-p12-pem": {
@@ -24105,36 +25747,6 @@
           "dev": true,
           "requires": {
             "detect-newline": "^2.1.0"
-          }
-        }
-      }
-    },
-    "jest-runner-aws-lambda": {
-      "version": "1.0.262",
-      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/jest-runner-aws-lambda/-/jest-runner-aws-lambda-1.0.262.tgz",
-      "integrity": "sha1-NojcEuvv8jZmO5UuHef7FXLl3OM=",
-      "dev": true,
-      "requires": {
-        "@wix/build-output-client": "1.0.156",
-        "aws-sdk": "^2.701.0",
-        "command-line-args": "^5.0.2",
-        "fed-tests-bi": "1.0.4",
-        "hot-shots": "^6.8.1",
-        "jest-teamcity": "^1.9.0",
-        "lodash": "^4.17.10",
-        "node-fetch": "^2.6.0",
-        "p-limit": "^3.0.1",
-        "request": "^2.88.0",
-        "shell-escape": "^0.2.0"
-      },
-      "dependencies": {
-        "p-limit": {
-          "version": "3.1.0",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/p-limit/-/p-limit-3.1.0.tgz",
-          "integrity": "sha1-4drMvnjQ0TiMoYxk/qOOPlfjcGs=",
-          "dev": true,
-          "requires": {
-            "yocto-queue": "^0.1.0"
           }
         }
       }
@@ -30740,6 +32352,24 @@
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/p-map/-/p-map-2.1.0.tgz",
       "integrity": "sha1-MQko/u+cnsxltosXaTAYpmXOoXU="
     },
+    "p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha1-IGip3PjmfdDsPnory3aBD6qF5CY=",
+      "dev": true,
+      "requires": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "4.0.7",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/eventemitter3/-/eventemitter3-4.0.7.tgz",
+          "integrity": "sha1-Lem2j2Uo1WRO9cWVJqG0oHMGFp8=",
+          "dev": true
+        }
+      }
+    },
     "p-reduce": {
       "version": "1.0.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/p-reduce/-/p-reduce-1.0.0.tgz",
@@ -33036,12 +34666,6 @@
       "integrity": "sha1-4QLxbKNVQkhldV0sno6k8k1Yw+I=",
       "dev": true
     },
-    "proxy-trace-access": {
-      "version": "1.0.5",
-      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/proxy-trace-access/-/proxy-trace-access-1.0.5.tgz",
-      "integrity": "sha1-HvuBNheLKhvHDyBPrW0wGM5+WD4=",
-      "dev": true
-    },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/prr/-/prr-1.0.1.tgz",
@@ -33177,48 +34801,6 @@
                 "ms": "^2.1.1"
               }
             }
-          }
-        },
-        "mime": {
-          "version": "2.4.6",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/mime/-/mime-2.4.6.tgz",
-          "integrity": "sha1-5bQHyQ20QvK+tbFiNz0Htpr/pNE=",
-          "dev": true
-        }
-      }
-    },
-    "puppeteer-core": {
-      "version": "2.1.0",
-      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/puppeteer-core/-/puppeteer-core-2.1.0.tgz",
-      "integrity": "sha1-bQhu0S1nNorQaXFDoZhoXeqI3hE=",
-      "dev": true,
-      "requires": {
-        "@types/mime-types": "^2.1.0",
-        "debug": "^4.1.0",
-        "extract-zip": "^1.6.6",
-        "https-proxy-agent": "^4.0.0",
-        "mime": "^2.0.3",
-        "mime-types": "^2.1.25",
-        "progress": "^2.0.1",
-        "proxy-from-env": "^1.0.0",
-        "rimraf": "^2.6.1",
-        "ws": "^6.1.0"
-      },
-      "dependencies": {
-        "agent-base": {
-          "version": "5.1.1",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/agent-base/-/agent-base-5.1.1.tgz",
-          "integrity": "sha1-6Ps/JClZ20TWO+Zl23qOc5U3oyw=",
-          "dev": true
-        },
-        "https-proxy-agent": {
-          "version": "4.0.0",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
-          "integrity": "sha1-cCtx+1UgoTKmbeH2dUHZ5iFU2Cs=",
-          "dev": true,
-          "requires": {
-            "agent-base": "5",
-            "debug": "4"
           }
         },
         "mime": {
@@ -36061,900 +37643,6 @@
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/slash/-/slash-3.0.0.tgz",
       "integrity": "sha1-ZTm+hwwWWtvVJAIg2+Nh8bxNRjQ="
     },
-    "sled-config": {
-      "version": "2.0.204",
-      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/sled-config/-/sled-config-2.0.204.tgz",
-      "integrity": "sha1-JG78fwOSmBrZDAdcazi6jJZhIZY=",
-      "dev": true
-    },
-    "sled-test-runner": {
-      "version": "1.0.806",
-      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/sled-test-runner/-/sled-test-runner-1.0.806.tgz",
-      "integrity": "sha1-z7GfX/uwLWPgmAzT+UqWgGwYWfY=",
-      "dev": true,
-      "requires": {
-        "@babel/plugin-proposal-class-properties": "^7.1.0",
-        "@babel/plugin-proposal-decorators": "^7.8.3",
-        "@babel/plugin-syntax-dynamic-import": "^7.0.0",
-        "@babel/plugin-transform-runtime": "^7.1.0",
-        "@babel/preset-env": "^7.1.0",
-        "@babel/preset-react": "^7.0.0",
-        "@babel/runtime": "7.7.6",
-        "@types/jest": "^24.0.11",
-        "@types/jest-image-snapshot": "^2.8.0",
-        "@types/node": "^12.19.7",
-        "@types/puppeteer": "^1.12.2",
-        "@types/vfile-message": "^2.0.0",
-        "@wix/ci-build-info": "1.0.130",
-        "@wix/puppeteer-interception-pipeline": "^1.0.155",
-        "@wix/sheshesh-image-snapshot": "^1.0.283",
-        "@wix/suricate-client": "^0.0.3",
-        "@zeit/webpack-asset-relocator-loader": "^0.8.0",
-        "aws-sdk": "^2.701.0",
-        "babel-jest": "^24.4.0",
-        "babel-loader": "^8.0.6",
-        "babel-plugin-dynamic-import-node": "^2.2.0",
-        "body-parser": "^1.19.0",
-        "chalk": "^2.4.2",
-        "chokidar": "*",
-        "chrome-launcher": "^0.11.2",
-        "command-line-args": "^5.0.2",
-        "command-line-usage": "^5.0.5",
-        "dependency-tree": "^7.0.2",
-        "express": "^4.17.1",
-        "fs-extra": "^8.0.1",
-        "globby": "^11.0.1",
-        "google-authenticator": "1.0.11",
-        "ini": "^1.3.5",
-        "is-ci": "^2.0.0",
-        "jest": "24.1.0",
-        "jest-runner-aws-lambda": "1.0.262",
-        "jest-teamcity": "^1.9.0",
-        "lodash": "^4.17.11",
-        "match-screenshot": "^3.0.131",
-        "micromatch": "^3.1.10",
-        "mime-types": "^2.1.27",
-        "node-fetch": "^2.6.0",
-        "node-notifier": "^6.0.0",
-        "null-loader": "^3.0.0",
-        "open": "^7.0.0",
-        "proxy-trace-access": "^1.0.2",
-        "puppeteer-core": "2.1.0",
-        "shelljs": "^0.8.3",
-        "sled-config": "2.0.204",
-        "snowmobile-runner": "1.0.82",
-        "tar": "^4.4.8",
-        "terser-webpack-plugin": "^4.1.0",
-        "thread-loader": "^2.1.3",
-        "ts-jest": "^24.0.0",
-        "ts-loader": "^8.0.0",
-        "webpack": "5.9.0",
-        "xmldoc": "^1.1.2"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.7.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "regenerator-runtime": "^0.13.2"
-          }
-        },
-        "@types/json-schema": {
-          "version": "7.0.6",
-          "bundled": true,
-          "dev": true
-        },
-        "@types/node": {
-          "version": "12.19.9",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@types/node/-/node-12.19.9.tgz",
-          "integrity": "sha1-mQrWh62LJu9tzDSk9pwz1AyVtnk=",
-          "dev": true
-        },
-        "acorn": {
-          "version": "8.0.4",
-          "bundled": true,
-          "dev": true
-        },
-        "ajv": {
-          "version": "6.12.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "anymatch": {
-          "version": "3.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "normalize-path": "^3.0.0",
-            "picomatch": "^2.0.4"
-          },
-          "dependencies": {
-            "normalize-path": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "babel-loader": {
-          "version": "8.0.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "find-cache-dir": "^2.0.0",
-            "loader-utils": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "pify": "^4.0.1"
-          }
-        },
-        "browserslist": {
-          "version": "4.14.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "caniuse-lite": "^1.0.30001157",
-            "colorette": "^1.2.1",
-            "electron-to-chromium": "^1.3.591",
-            "escalade": "^3.1.1",
-            "node-releases": "^1.1.66"
-          }
-        },
-        "cacache": {
-          "version": "15.0.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@npmcli/move-file": "^1.0.1",
-            "chownr": "^2.0.0",
-            "fs-minipass": "^2.0.0",
-            "glob": "^7.1.4",
-            "infer-owner": "^1.0.4",
-            "lru-cache": "^6.0.0",
-            "minipass": "^3.1.1",
-            "minipass-collect": "^1.0.2",
-            "minipass-flush": "^1.0.5",
-            "minipass-pipeline": "^1.2.2",
-            "mkdirp": "^1.0.3",
-            "p-map": "^4.0.0",
-            "promise-inflight": "^1.0.1",
-            "rimraf": "^3.0.2",
-            "ssri": "^8.0.0",
-            "tar": "^6.0.2",
-            "unique-filename": "^1.1.1"
-          },
-          "dependencies": {
-            "mkdirp": {
-              "version": "1.0.4",
-              "bundled": true,
-              "dev": true
-            },
-            "tar": {
-              "version": "6.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "chownr": "^2.0.0",
-                "fs-minipass": "^2.0.0",
-                "minipass": "^3.0.0",
-                "minizlib": "^2.1.0",
-                "mkdirp": "^1.0.3",
-                "yallist": "^4.0.0"
-              }
-            }
-          }
-        },
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001164",
-          "bundled": true,
-          "dev": true
-        },
-        "chokidar": {
-          "version": "3.4.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "anymatch": "~3.1.1",
-            "braces": "~3.0.2",
-            "fsevents": "~2.1.2",
-            "glob-parent": "~5.1.0",
-            "is-binary-path": "~2.1.0",
-            "is-glob": "~4.0.1",
-            "normalize-path": "~3.0.0",
-            "readdirp": "~3.5.0"
-          },
-          "dependencies": {
-            "normalize-path": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "chownr": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "electron-to-chromium": {
-          "version": "1.3.612",
-          "bundled": true,
-          "dev": true
-        },
-        "eslint-scope": {
-          "version": "5.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "esrecurse": "^4.3.0",
-            "estraverse": "^4.1.1"
-          }
-        },
-        "esrecurse": {
-          "version": "4.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "estraverse": "^5.2.0"
-          },
-          "dependencies": {
-            "estraverse": {
-              "version": "5.2.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "events": {
-          "version": "3.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "fast-deep-equal": {
-          "version": "3.1.3",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-          "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
-          "dev": true
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha1-SdQ8RaiM2Wd2aMt74bRu/bjS4cA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "fs-minipass": {
-          "version": "2.1.0",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/fs-minipass/-/fs-minipass-2.1.0.tgz",
-          "integrity": "sha1-f1A2/b8SxjwWkZDL5BmchSJx+fs=",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.0.0"
-          }
-        },
-        "glob-parent": {
-          "version": "5.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-glob": "^4.0.1"
-          }
-        },
-        "glob-to-regexp": {
-          "version": "0.4.1",
-          "bundled": true,
-          "dev": true
-        },
-        "graceful-fs": {
-          "version": "4.2.4",
-          "bundled": true,
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "jest-worker": {
-          "version": "26.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@types/node": "*",
-            "merge-stream": "^2.0.0",
-            "supports-color": "^7.0.0"
-          },
-          "dependencies": {
-            "@types/node": {
-              "version": "13.7.2",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "json5": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
-        },
-        "loader-runner": {
-          "version": "4.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "make-dir": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "semver": "^6.0.0"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "6.3.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "micromatch": {
-          "version": "3.1.10",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
-          },
-          "dependencies": {
-            "braces": {
-              "version": "2.3.2",
-              "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/braces/-/braces-2.3.2.tgz",
-              "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
-              "dev": true,
-              "requires": {
-                "arr-flatten": "^1.1.0",
-                "array-unique": "^0.3.2",
-                "extend-shallow": "^2.0.1",
-                "fill-range": "^4.0.0",
-                "isobject": "^3.0.1",
-                "repeat-element": "^1.1.2",
-                "snapdragon": "^0.8.1",
-                "snapdragon-node": "^2.0.1",
-                "split-string": "^3.0.2",
-                "to-regex": "^3.0.1"
-              },
-              "dependencies": {
-                "extend-shallow": {
-                  "version": "2.0.1",
-                  "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                  "dev": true,
-                  "requires": {
-                    "is-extendable": "^0.1.0"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "mime-db": {
-          "version": "1.44.0",
-          "bundled": true,
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.27",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "mime-db": "1.44.0"
-          }
-        },
-        "minipass": {
-          "version": "3.1.3",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/minipass/-/minipass-3.1.3.tgz",
-          "integrity": "sha1-fUL/HzljVILhX5zbUxhN7r1YFf0=",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minipass": "^3.0.0",
-            "yallist": "^4.0.0"
-          }
-        },
-        "neo-async": {
-          "version": "2.6.2",
-          "bundled": true,
-          "dev": true
-        },
-        "node-releases": {
-          "version": "1.1.67",
-          "bundled": true,
-          "dev": true
-        },
-        "null-loader": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loader-utils": "^1.2.3",
-            "schema-utils": "^1.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-map": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "aggregate-error": "^3.0.0"
-          }
-        },
-        "pify": {
-          "version": "4.0.1",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
-          "dev": true
-        },
-        "readdirp": {
-          "version": "3.5.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "picomatch": "^2.2.1"
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.13.3",
-          "bundled": true,
-          "dev": true
-        },
-        "rimraf": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "schema-utils": {
-          "version": "1.0.0",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/schema-utils/-/schema-utils-1.0.0.tgz",
-          "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
-          "dev": true,
-          "requires": {
-            "ajv": "^6.1.0",
-            "ajv-errors": "^1.0.0",
-            "ajv-keywords": "^3.1.0"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
-          "dev": true
-        },
-        "ssri": {
-          "version": "8.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minipass": "^3.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "7.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "tapable": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "terser": {
-          "version": "5.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "commander": "^2.20.0",
-            "source-map": "~0.6.1",
-            "source-map-support": "~0.5.12"
-          }
-        },
-        "terser-webpack-plugin": {
-          "version": "4.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "cacache": "^15.0.5",
-            "find-cache-dir": "^3.3.1",
-            "jest-worker": "^26.3.0",
-            "p-limit": "^3.0.2",
-            "schema-utils": "^2.6.6",
-            "serialize-javascript": "^4.0.0",
-            "source-map": "^0.6.1",
-            "terser": "^5.0.0",
-            "webpack-sources": "^1.4.3"
-          },
-          "dependencies": {
-            "find-cache-dir": {
-              "version": "3.3.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "commondir": "^1.0.1",
-                "make-dir": "^3.0.2",
-                "pkg-dir": "^4.1.0"
-              }
-            },
-            "schema-utils": {
-              "version": "2.6.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ajv": "^6.12.0",
-                "ajv-keywords": "^3.4.1"
-              }
-            }
-          }
-        },
-        "to-regex-range": {
-          "version": "2.1.1",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/to-regex-range/-/to-regex-range-2.1.1.tgz",
-          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-          "dev": true,
-          "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
-          }
-        },
-        "ts-jest": {
-          "version": "24.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bs-logger": "0.x",
-            "buffer-from": "1.x",
-            "fast-json-stable-stringify": "2.x",
-            "json5": "2.x",
-            "lodash.memoize": "4.x",
-            "make-error": "1.x",
-            "mkdirp": "0.x",
-            "resolve": "1.x",
-            "semver": "^5.5",
-            "yargs-parser": "10.x"
-          }
-        },
-        "ts-loader": {
-          "version": "8.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "chalk": "^2.3.0",
-            "enhanced-resolve": "^4.0.0",
-            "loader-utils": "^1.0.2",
-            "micromatch": "^4.0.0",
-            "semver": "^6.0.0"
-          },
-          "dependencies": {
-            "micromatch": {
-              "version": "4.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "braces": "^3.0.1",
-                "picomatch": "^2.0.5"
-              }
-            },
-            "picomatch": {
-              "version": "2.2.1",
-              "bundled": true,
-              "dev": true
-            },
-            "semver": {
-              "version": "6.3.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "universalify": {
-          "version": "0.1.2",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/universalify/-/universalify-0.1.2.tgz",
-          "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
-          "dev": true
-        },
-        "watchpack": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "glob-to-regexp": "^0.4.1",
-            "graceful-fs": "^4.1.2"
-          },
-          "dependencies": {
-            "graceful-fs": {
-              "version": "4.2.3",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "webpack": {
-          "version": "5.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@types/eslint-scope": "^3.7.0",
-            "@types/estree": "^0.0.45",
-            "@webassemblyjs/ast": "1.9.0",
-            "@webassemblyjs/helper-module-context": "1.9.0",
-            "@webassemblyjs/wasm-edit": "1.9.0",
-            "@webassemblyjs/wasm-parser": "1.9.0",
-            "acorn": "^8.0.4",
-            "browserslist": "^4.14.5",
-            "chrome-trace-event": "^1.0.2",
-            "enhanced-resolve": "^5.3.1",
-            "eslint-scope": "^5.1.1",
-            "events": "^3.2.0",
-            "glob-to-regexp": "^0.4.1",
-            "graceful-fs": "^4.2.4",
-            "json-parse-better-errors": "^1.0.2",
-            "loader-runner": "^4.1.0",
-            "mime-types": "^2.1.27",
-            "neo-async": "^2.6.2",
-            "pkg-dir": "^4.2.0",
-            "schema-utils": "^3.0.0",
-            "tapable": "^2.1.1",
-            "terser-webpack-plugin": "^5.0.3",
-            "watchpack": "^2.0.0",
-            "webpack-sources": "^2.1.1"
-          },
-          "dependencies": {
-            "@types/node": {
-              "version": "13.7.2",
-              "bundled": true,
-              "dev": true
-            },
-            "ajv": {
-              "version": "6.12.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
-              }
-            },
-            "ajv-keywords": {
-              "version": "3.5.2",
-              "bundled": true,
-              "dev": true
-            },
-            "enhanced-resolve": {
-              "version": "5.3.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "graceful-fs": "^4.2.4",
-                "tapable": "^2.0.0"
-              },
-              "dependencies": {
-                "tapable": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "jest-worker": {
-              "version": "26.6.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "@types/node": "*",
-                "merge-stream": "^2.0.0",
-                "supports-color": "^7.0.0"
-              }
-            },
-            "schema-utils": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "@types/json-schema": "^7.0.6",
-                "ajv": "^6.12.5",
-                "ajv-keywords": "^3.5.2"
-              }
-            },
-            "serialize-javascript": {
-              "version": "5.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "randombytes": "^2.1.0"
-              }
-            },
-            "source-map-support": {
-              "version": "0.5.19",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "buffer-from": "^1.0.0",
-                "source-map": "^0.6.0"
-              }
-            },
-            "terser": {
-              "version": "5.5.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "commander": "^2.20.0",
-                "source-map": "~0.7.2",
-                "source-map-support": "~0.5.19"
-              },
-              "dependencies": {
-                "source-map": {
-                  "version": "0.7.3",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "terser-webpack-plugin": {
-              "version": "5.0.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "jest-worker": "^26.6.1",
-                "p-limit": "^3.0.2",
-                "schema-utils": "^3.0.0",
-                "serialize-javascript": "^5.0.1",
-                "source-map": "^0.6.1",
-                "terser": "^5.3.8"
-              }
-            },
-            "webpack-sources": {
-              "version": "2.2.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "source-list-map": "^2.0.1",
-                "source-map": "^0.6.1"
-              }
-            }
-          }
-        },
-        "webpack-sources": {
-          "version": "1.4.3",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/webpack-sources/-/webpack-sources-1.4.3.tgz",
-          "integrity": "sha1-7t2OwLko+/HL/plOItLYkPMwqTM=",
-          "dev": true,
-          "requires": {
-            "source-list-map": "^2.0.0",
-            "source-map": "~0.6.1"
-          }
-        },
-        "yargs-parser": {
-          "version": "10.1.0",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/yargs-parser/-/yargs-parser-10.1.0.tgz",
-          "integrity": "sha1-cgImW4n36eny5XZeD+c1qQXtuqg=",
-          "dev": true,
-          "requires": {
-            "camelcase": "^4.1.0"
-          }
-        }
-      }
-    },
     "slice-ansi": {
       "version": "3.0.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/slice-ansi/-/slice-ansi-3.0.0.tgz",
@@ -37126,29 +37814,6 @@
         "bindings": "^1.3.1",
         "nan": "^2.14.1",
         "prebuild-install": "5.3.0"
-      }
-    },
-    "snowmobile-runner": {
-      "version": "1.0.82",
-      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/snowmobile-runner/-/snowmobile-runner-1.0.82.tgz",
-      "integrity": "sha1-pUtBAjxuztziCk7QSCouFkVpTmM=",
-      "dev": true,
-      "requires": {
-        "@wix/build-output-client": "1.0.156",
-        "aws-sdk": "^2.701.0",
-        "lodash": "^4.17.15",
-        "p-limit": "^3.0.1"
-      },
-      "dependencies": {
-        "p-limit": {
-          "version": "3.1.0",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/p-limit/-/p-limit-3.1.0.tgz",
-          "integrity": "sha1-4drMvnjQ0TiMoYxk/qOOPlfjcGs=",
-          "dev": true,
-          "requires": {
-            "yocto-queue": "^0.1.0"
-          }
-        }
       }
     },
     "sntp": {
@@ -37592,6 +38257,15 @@
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
+    },
+    "stream": {
+      "version": "0.0.2",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/stream/-/stream-0.0.2.tgz",
+      "integrity": "sha1-f1Nj8Ff2WSxVlfALyAon9c7B8O8=",
+      "dev": true,
+      "requires": {
+        "emitter-component": "^1.1.1"
+      }
     },
     "stream-browserify": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lint-staged": "^10.0.7",
     "puppeteer": "^1.10.0",
     "react": "16.13.1",
-    "sled-test-runner": "^1.0.0",
+    "@wix/sled-test-runner": "^1.0.0",
     "typescript": "~3.9.0",
     "yoshi-flow-bm": "^4.1.0"
   },

--- a/sled/index-page.perf.spec.ts
+++ b/sled/index-page.perf.spec.ts
@@ -1,4 +1,4 @@
-/// <reference types="sled-test-runner" />
+/// <reference types="@wix/sled-test-runner" />
 import { benchmark } from '@wix/perfer-sled';
 import { injectBMOverrides } from 'yoshi-flow-bm';
 

--- a/sled/index-page.spec.ts
+++ b/sled/index-page.spec.ts
@@ -1,4 +1,4 @@
-/// <reference types="sled-test-runner" />
+/// <reference types="@wix/sled-test-runner" />
 import { Page } from 'puppeteer';
 import { injectBMOverrides } from 'yoshi-flow-bm';
 import { TextTestkit } from 'wix-style-react/dist/testkit/puppeteer';


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 5.856s
npm WARN deprecated @types/chalk@2.2.0: This is a stub types definition for chalk (https://github.com/chalk/chalk). chalk provides its own type definitions, so you don't need @types/chalk installed!
npm WARN deprecated debug@4.1.1: Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)
node-pre-gyp WARN Using request for node-pre-gyp https download 
node-pre-gyp WARN Using request for node-pre-gyp https download 
npm WARN wix-ui-core@3.0.163 requires a peer of @stylable/dom-test-kit@^3.4.1 but none is installed. You must install peer dependencies yourself.

npm WARN null-loader@3.0.0 requires a peer of webpack@^4.3.0 but none is installed. You must install peer dependencies yourself.
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@2.1.3 (node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.1.3: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})




Output Log:
Migrating package "@wix/test" in .


## Migration from non scope to @wix/scoped packages
> /tmp/fa8c60d20072c1ca1c7645ab499c4f80

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace reference types and shorthand ambient module types in ts & d.ts files
```
sled/index-page.perf.spec.ts
sled/index-page.spec.ts
```

#### replace bi-logger usages in .application.json/.module.json
```
.module.json
```

> v8-profiler-node8@6.3.0 preinstall /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/v8-profiler-node8
> node -e 'process.exit(0)'


> fmerge@1.2.0 install /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/fmerge
> node install.js

`fmerge.min.js` created

> @newrelic/native-metrics@5.3.0 install /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@newrelic/native-metrics
> node ./lib/pre-build.js install native_metrics

============================================================================
Attempting install in native-metrics module. Please note that this is an
OPTIONAL dependency, and any resultant errors in this process will not
affect the general performance of the New Relic agent, but event loop and
garbage collection metrics will not be collected.
============================================================================

> /usr/local/bin/node /usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js clean configure
> /usr/local/bin/node /usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js build -j 8 native_metrics
make: Entering directory '/tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@newrelic/native-metrics/build'
  CXX(target) Release/obj.target/native_metrics/src/native_metrics.o
  CXX(target) Release/obj.target/native_metrics/src/GCBinder.o
  CXX(target) Release/obj.target/native_metrics/src/LoopChecker.o
  CXX(target) Release/obj.target/native_metrics/src/RUsageMeter.o
  SOLINK_MODULE(target) Release/obj.target/native_metrics.node
  COPY Release/native_metrics.node
make: Leaving directory '/tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@newrelic/native-metrics/build'
install successful: _newrelic_native_metrics-5_3_0-native_metrics-72-linux-x64

> @newrelic/native-metrics@6.0.0 install /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/serverless-runtime-server/node_modules/@newrelic/native-metrics
> node ./lib/pre-build.js install native_metrics

============================================================================
Attempting install in native-metrics module. Please note that this is an
OPTIONAL dependency, and any resultant errors in this process will not
affect the general performance of the New Relic agent, but event loop and
garbage collection metrics will not be collected.
============================================================================

> /usr/local/bin/node /usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js clean configure
> /usr/local/bin/node /usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js build -j 8 native_metrics
make: Entering directory '/tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/serverless-runtime-server/node_modules/@newrelic/native-metrics/build'
  CXX(target) Release/obj.target/native_metrics/src/native_metrics.o
  CXX(target) Release/obj.target/native_metrics/src/GCBinder.o
  CXX(target) Release/obj.target/native_metrics/src/LoopChecker.o
  CXX(target) Release/obj.target/native_metrics/src/RUsageMeter.o
  SOLINK_MODULE(target) Release/obj.target/native_metrics.node
  COPY Release/native_metrics.node
make: Leaving directory '/tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/serverless-runtime-server/node_modules/@newrelic/native-metrics/build'
install successful: _newrelic_native_metrics-6_0_0-native_metrics-72-linux-x64

> dtrace-provider@0.8.8 install /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/dtrace-provider
> node-gyp rebuild || node suppress-error.js

make: Entering directory '/tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/dtrace-provider/build'
  TOUCH Release/obj.target/DTraceProviderStub.stamp
make: Leaving directory '/tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/dtrace-provider/build'

> grpc@1.24.4 install /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/grpc
> node-pre-gyp install --fallback-to-build --library=static_library

[grpc] Success: "/tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/grpc/src/node/extension_binary/node-v72-linux-x64-glibc/grpc_node.node" is installed via remote

> v8-profiler-node8@6.3.0 install /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/v8-profiler-node8
> node-pre-gyp install --fallback-to-build

[v8-profiler-node8] Success: "/tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/v8-profiler-node8/build/binding/Release/node-v72-linux-x64/profiler.node" is installed via remote

> snappy@6.3.5 install /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/snappy
> prebuild-install || node-gyp rebuild


> @wix/ambassador-app-settings-service@1.0.76 postinstall /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/ambassador-app-settings-service
> node ./export-erb.js com.wixpress.fed.app-settings-service

successfully added AppSettingsService to /templates/ambassador.json.erb

> @wix/ambassador-cronulla@1.0.11 postinstall /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/ambassador-cronulla
> node ./export-erb.js com.wixpress.cronulla

successfully added Cronulla to /templates/ambassador.json.erb

> @wix/ambassador-payment-services-web@2.0.1254 postinstall /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/ambassador-payment-services-web
> node ./export-erb.js com.wixpress.payment.payment-services-web

successfully added PaymentServicesWeb to /templates/ambassador.json.erb

> @wix/ambassador-site-properties-service@2.0.45 postinstall /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/ambassador-site-properties-service
> node ./export-erb.js com.wixpress.siteproperties.site-properties-service

successfully added SitePropertiesService to /templates/ambassador.json.erb

> fast-xml-parser@3.17.4 postinstall /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wix-config/node_modules/fast-xml-parser
> node tasks/postinstall.js || exit 0

[96m[1mLove fast-xml-parser? Check [32mhttps://amitkumargupta.work [96m[1mfor more projects and contribution.[0m


> @wix/wix-bootstrap-greynode-config-template@1.0.626 postinstall /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wix-bootstrap-greynode-config-template
> copy-config-templates

copy-config-templates(@wix/wix-bootstrap-greynode-config-template): NODE_ENV='production', copying configs from '/tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wix-bootstrap-greynode-config-template/templates' to '/templates'

> ejs@2.7.4 postinstall /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wix-ejs-renderer/node_modules/ejs
> node ./postinstall.js


> @wix/wnp-bootstrap-mysql-config-template@1.0.1561 postinstall /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wnp-bootstrap-mysql-config-template
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-mysql-config-template): NODE_ENV='production', copying configs from '/tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wnp-bootstrap-mysql-config-template/templates' to '/templates'

> core-js@3.8.1 postinstall /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/core-js
> node -e "try{require('./postinstall')}catch(e){}"


> fast-xml-parser@3.17.5 postinstall /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/fast-xml-parser
> node tasks/postinstall.js || exit 0

[96m[1mLove fast-xml-parser? Check [32mhttps://amitkumargupta.work [96m[1mfor more projects and contribution.[0m


> protobufjs@6.10.1 postinstall /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/protobufjs
> node scripts/postinstall


> sinon@4.5.0 postinstall /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/sinon
> node scripts/support-sinon.js

[32mHave some ❤️ for Sinon? You can support the project via Open Collective:[22m[39m
 > [96m[1mhttps://opencollective.com/sinon/donate
[0m

> @wix/ambassador@4.0.476 postinstall /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/ambassador
> ambassador export --ci || echo '[Ambassador] Skipping ambassador.json.erb generation'

✓ Created Ambassador configuration at /templates/ambassador.json.erb

> @wix/wix-bootstrap-bo-auth@1.0.2024 postinstall /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wix-bootstrap-bo-auth
> copy-config-templates

copy-config-templates(@wix/wix-bootstrap-bo-auth): NODE_ENV='production', copying configs from '/tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wix-bootstrap-bo-auth/templates' to '/templates'

> @wix/wix-bootstrap-require-login@1.0.1870 postinstall /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wix-bootstrap-require-login
> copy-config-templates

copy-config-templates(@wix/wix-bootstrap-require-login): NODE_ENV='production', copying configs from '/tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wix-bootstrap-require-login/templates' to '/templates'

> @wix/wix-bootstrap-s2s-signer@1.0.960 postinstall /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wix-bootstrap-s2s-signer
> copy-config-templates

copy-config-templates(@wix/wix-bootstrap-s2s-signer): NODE_ENV='production', copying configs from '/tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wix-bootstrap-s2s-signer/templates' to '/templates'

> @wix/wnp-bootstrap-aspects@1.0.1161 postinstall /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wnp-bootstrap-aspects
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-aspects): NODE_ENV='production', copying configs from '/tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wnp-bootstrap-aspects/templates' to '/templates'

> @wix/wnp-bootstrap-consent-policy@1.0.69 postinstall /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wnp-bootstrap-consent-policy
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-consent-policy): NODE_ENV='production', copying configs from '/tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wnp-bootstrap-consent-policy/templates' to '/templates'

> @wix/wnp-bootstrap-framework-config@1.0.17 postinstall /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wnp-bootstrap-framework-config
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-framework-config): NODE_ENV='production', copying configs from '/tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wnp-bootstrap-framework-config/templates' to '/templates'

> @wix/wnp-bootstrap-petri@1.0.2071 postinstall /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wnp-bootstrap-petri
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-petri): NODE_ENV='production', copying configs from '/tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wnp-bootstrap-petri/templates' to '/templates'

> @wix/wnp-bootstrap-session@1.0.1719 postinstall /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wnp-bootstrap-session
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-session): NODE_ENV='production', copying configs from '/tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wnp-bootstrap-session/templates' to '/templates'

> @wix/wnp-bootstrap-statsd@1.0.1648 postinstall /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wnp-bootstrap-statsd
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-statsd): NODE_ENV='production', copying configs from '/tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wnp-bootstrap-statsd/templates' to '/templates'

> @wix/wnp-bootstrap-tracing@1.0.971 postinstall /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wnp-bootstrap-tracing
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-tracing): NODE_ENV='production', copying configs from '/tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wnp-bootstrap-tracing/templates' to '/templates'

> @wix/wnp-bootstrap-petri-specs@0.1.1742 postinstall /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wnp-bootstrap-petri-specs
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-petri-specs): NODE_ENV='production', copying configs from '/tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wnp-bootstrap-petri-specs/templates' to '/templates'

> @wix/wnp-bootstrap-rpc-signing@1.0.1081 postinstall /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wnp-bootstrap-rpc-signing
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-rpc-signing): NODE_ENV='production', copying configs from '/tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wnp-bootstrap-rpc-signing/templates' to '/templates'

> @wix/wnp-bootstrap-express@1.0.2455 postinstall /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wnp-bootstrap-express
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-express): NODE_ENV='production', copying configs from '/tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wnp-bootstrap-express/templates' to '/templates'

> @wix/wnp-bootstrap-grpc@1.0.1022 postinstall /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wnp-bootstrap-grpc
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-grpc): NODE_ENV='production', copying configs from '/tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wnp-bootstrap-grpc/templates' to '/templates'

> @wix/serverless-template@1.0.14 postinstall /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/serverless-template
> copy-config-templates

copy-config-templates(@wix/serverless-template): NODE_ENV='production', copying configs from '/tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/serverless-template/templates' to '/templates'

> wix-ui-core@3.0.163 postinstall /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/wix-ui-core
> npm install @stylable/dom-test-kit --no-save

+ @stylable/dom-test-kit@4.0.1
added 42 packages from 57 contributors in 1.454s

6 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities


> @wix/wix-bootstrap-greyhound@1.0.322 postinstall /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wix-bootstrap-greyhound
> copy-config-templates

copy-config-templates(@wix/wix-bootstrap-greyhound): NODE_ENV='production', copying configs from '/tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wix-bootstrap-greyhound/templates' to '/templates'

> @wix/wnp-bootstrap-composer@0.1.4103 postinstall /tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wnp-bootstrap-composer
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-composer): NODE_ENV='production', copying configs from '/tmp/fa8c60d20072c1ca1c7645ab499c4f80/node_modules/@wix/wnp-bootstrap-composer/templates' to '/templates'
added 1753 packages from 1482 contributors and audited 5104 packages in 78.276s

96 packages are looking for funding
  run `npm fund` for details

found 1809 vulnerabilities (135 low, 1485 moderate, 187 high, 2 critical)
  run `npm audit fix` to fix them, or `npm audit` for details

